### PR TITLE
Wildcard paths and exceptions

### DIFF
--- a/lib/roles.php
+++ b/lib/roles.php
@@ -486,12 +486,8 @@ function roles_path_match($rule, $path) {
 		$pattern = preg_replace('/\)$/', '', $pattern);
 		return preg_match($pattern, $path);
 	} else {
-
 		// The rule contains a simple string or a wildcard
-		$siteurl = elgg_get_site_url();
-		$normalized_path = elgg_normalize_url($path);
-		$pattern = "`^{$siteurl}{$rule}/*$`i";
-		return ($rule == $path || preg_match($pattern, $normalized_path));
+		return ($rule == $path || preg_match($pattern, "`^{$rule}/*$`i"));
 	}
 }
 

--- a/lib/roles.php
+++ b/lib/roles.php
@@ -486,8 +486,12 @@ function roles_path_match($rule, $path) {
 		$pattern = preg_replace('/\)$/', '', $pattern);
 		return preg_match($pattern, $path);
 	} else {
-		// The rule contains a simple string; default string comparision will be used
-		return ($rule == $path);
+
+		// The rule contains a simple string or a wildcard
+		$siteurl = elgg_get_site_url();
+		$normalized_path = elgg_normalize_url($path);
+		$pattern = "`^{$siteurl}{$rule}/*$`i";
+		return ($rule == $path || preg_match($pattern, $normalized_path));
 	}
 }
 

--- a/lib/roles.php
+++ b/lib/roles.php
@@ -487,7 +487,7 @@ function roles_path_match($rule, $path) {
 		return preg_match($pattern, $path);
 	} else {
 		// The rule contains a simple string or a wildcard
-		return ($rule == $path || preg_match($pattern, "`^{$rule}/*$`i"));
+		return ($rule == $path || preg_match("`^{$rule}/*$`i", $path));
 	}
 }
 
@@ -513,6 +513,27 @@ function roles_check_context($permission_details, $strict = false) {
 		}
 	}
 	return $result;
+}
+
+/**
+ *
+ * Checks if a permission rule has exceptions that apply to current path
+ *
+ * @param string $permission_details The permission rule configuration
+ * @param string $path The path to match against
+ *
+ * @return True if the rule should be executed, false otherwise
+ */
+function roles_check_path_exceptions($permission_details, $path) {
+	if (is_array($permission_details['exceptions'])) {
+		foreach ($permission_details['exceptions'] as $exception) {
+			$exception = roles_replace_dynamic_paths($exception);
+			if (roles_path_match($exception, $path)) {
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 /**

--- a/start.php
+++ b/start.php
@@ -155,7 +155,9 @@ function roles_actions_permissions($hook, $type, $return_value, $params) {
 		$role_perms = roles_get_role_permissions($role, 'actions');
 		if (is_array($role_perms) && !empty($role_perms)) {
 			foreach ($role_perms as $action => $perm_details) {
-				if (roles_path_match(roles_replace_dynamic_paths($action), $type)) {
+				if (roles_path_match(roles_replace_dynamic_paths($action), $type)
+						&& roles_check_path_exceptions($perm_details, $type)) {
+
 					switch ($perm_details['rule']) {
 						case 'deny':
 							register_error(elgg_echo('roles:action:denied'));
@@ -248,7 +250,8 @@ function roles_pages_permissions($hook_name, $type, $return_value, $params) {
 		$page_path = $return_value['handler'] . '/' . implode('/', $return_value['segments']);
 		if (is_array($role_perms) && !empty($role_perms)) {
 			foreach ($role_perms as $page => $perm_details) {
-				if (roles_path_match(roles_replace_dynamic_paths($page), $page_path)) {
+				if (roles_path_match(roles_replace_dynamic_paths($page), $page_path)
+						&& roles_check_path_exceptions($perm_details, $page_path)) {
 					switch ($perm_details['rule']) {
 						case 'deny':
 							register_error(elgg_echo('roles:page:denied'));


### PR DESCRIPTION
Working with regexp is too much hassle. I propose the following:

```
'blog/add/.*' => array(
    'rule' => 'deny',
    'exceptions' => array(
        'blog/add/{$self_guid}'
    )
)
```

The above will deny access to all pages for adding a blog except for self. So, the user won't be able to add blogs to groups for example.
Implementing this with regexp creates unreadable garbage, especially if you have more than 3 exceptions.
